### PR TITLE
Adds name colors support for advancements and the tab list

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.4
-yarn_mappings=1.21.4+build.8
+minecraft_version=1.21.1
+yarn_mappings=1.21.1+build.3
 loader_version=0.16.10
 # Mod Properties
 mod_version=1.0.0

--- a/src/main/java/dev/jolkert/namecolor/mixin/PlayerEntityMixin.java
+++ b/src/main/java/dev/jolkert/namecolor/mixin/PlayerEntityMixin.java
@@ -1,0 +1,36 @@
+package dev.jolkert.namecolor.mixin;
+
+import dev.jolkert.namecolor.NameColor;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.text.Style;
+import net.minecraft.text.Text;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(PlayerEntity.class)
+public abstract class PlayerEntityMixin extends LivingEntity {
+  protected PlayerEntityMixin(EntityType<? extends LivingEntity> entityType, World world) {
+    super(entityType, world);
+  }
+
+  @Inject(method = "getName", at = @At("RETURN"), cancellable = true)
+  public void getName(CallbackInfoReturnable<Text> cir) {
+    Text original = cir.getReturnValue();
+    int color = NameColor.getNameColor(this.getUuid());
+
+    cir.setReturnValue(color != -1 ? original.copy().setStyle(Style.EMPTY.withColor(color)) : original);
+  }
+
+  @Inject(method = "getDisplayName", at = @At("RETURN"), cancellable = true)
+  public void getDisplayName(CallbackInfoReturnable<Text> cir) {
+    Text original = cir.getReturnValue();
+    int color = NameColor.getNameColor(this.getUuid());
+
+    cir.setReturnValue(color != -1 ? original.copy().setStyle(Style.EMPTY.withColor(color)) : original);
+  }
+}

--- a/src/main/java/dev/jolkert/namecolor/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/dev/jolkert/namecolor/mixin/ServerPlayerEntityMixin.java
@@ -1,0 +1,29 @@
+package dev.jolkert.namecolor.mixin;
+
+import com.mojang.authlib.GameProfile;
+import dev.jolkert.namecolor.NameColor;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Style;
+import net.minecraft.text.Text;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ServerPlayerEntity.class)
+public abstract class ServerPlayerEntityMixin extends PlayerEntity {
+  public ServerPlayerEntityMixin(World world, BlockPos pos, float yaw, GameProfile gameProfile) {
+    super(world, pos, yaw, gameProfile);
+  }
+
+  @Inject(method = "getPlayerListName", at = @At("RETURN"), cancellable = true)
+  public void getPlayerListName(CallbackInfoReturnable<Text> cir) {
+    Text original = cir.getReturnValue();
+    int color = NameColor.getNameColor(this.getUuid());
+
+    cir.setReturnValue(color != -1 ? this.getDisplayName().copy().setStyle(Style.EMPTY.withColor(color)) : original);
+  }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,6 +20,6 @@
   "depends": {
 	"fabricloader": ">=${loader_version}",
 	"fabric": "*",
-	"minecraft": "${minecraft_version}"
+	"minecraft": ">1.21"
   }
 }

--- a/src/main/resources/name_color.mixins.json
+++ b/src/main/resources/name_color.mixins.json
@@ -4,7 +4,9 @@
   "package": "dev.jolkert.namecolor.mixin",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
-	"NameColorMixin"
+    "NameColorMixin",
+    "PlayerEntityMixin",
+    "ServerPlayerEntityMixin"
   ],
   "injectors": {
 	"defaultRequire": 1


### PR DESCRIPTION
Hey, really big fan of this mod, been wanting more flexibility for player name colours than the vanilla team colours allow. This mod is the perfect level of simple - been using it on my server and everyone is really happy.

This PR expands the support for name colors to advancement chat notifications, as well as the tab player list. (Though the tab player list seems to be set on player log-in, so relogging once is required after setting a colour for the first time.) I tried to get nameplate colours working too, so it covered all places that team colours does, but that seems to rely on changing packets to the client, so may not be possible entirely server-side, or at least not as simply as the rest of the implementations.

I'm still relatively new to Java and Mixins, so this may need tidying up, but thought I would get an initial PR in since it works well.

The mod also seems to work out of the box on 1.21.1 (that my server is currently on), just from changing the required version in the `fabric.mod.json`, so there's a good chance it works on all of 1.21 if not even older versions.